### PR TITLE
Fix "simple" product type display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1036,7 +1036,7 @@ TODO: what to do with the `available_on` attribute from Spree?
   - product has options
   - product has variants
 - Effects of using `type_id: "configurable"`:
-  - product variants must be a list (can be empty)
+  - product variants must be a list (cannot be empty, because VS-api skips returning empty lists and that causes JS errors in VS)
 - The only fields required for custom attributes are: `attribute_code`, `is_user_defined=true`, `is_visible_on_front=true` and `is_visible=true`.
 - `configurable_options` in a product is not required if variants cannot be selected with options.
 - To change the currency symbol for products displayed by VS (non-multistore), modify config/local.json. The option `i18n` contains `currency*` options.

--- a/src/importers/product.ts
+++ b/src/importers/product.ts
@@ -145,7 +145,7 @@ const importProducts = (
         // In Magento, value of 1 is not used.
         tax_class_id: 2,
         thumbnail: getImageUrl(images[0] as SpreeProductImage, 800, 800) || '',
-        type_id: 'configurable',
+        type_id: variants.length === 0 ? 'simple' : 'configurable',
         // created_at - not currently returned by Spree and not used by VS by default
         updated_at: product.attributes.updated_at, // used for sorting and filtering
         // visibility. From Magento: 1 - Visible Individually, 2 - catalog, 3 - search, 4 - catalog & search


### PR DESCRIPTION
VS-api does not return fields containing an empty array (`[]`). When displaying a `type: simple` product as `type: configurable` with `configurable_children: []`, VS returns a `find function doesn't exist on undefined`. This PR solves this issue.

Example of broken product: `localhost:3000/p/SPR-00001/spree-baseball-jersey-8/SPR-00001`